### PR TITLE
Don't load as binary

### DIFF
--- a/reyaml/__init__.py
+++ b/reyaml/__init__.py
@@ -38,6 +38,6 @@ def load(raw):
 
 def load_from_file(path):
     '''Load a YAML file and return its contents as a dictionary'''
-    with open(path, 'rb') as f:
+    with open(path, 'r') as f:
         raw = f.read()
         return load(raw)

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ to the data and fails verbosely, providing a detailed error message.'''
 setup(
     name = 'reyaml',
     packages = ['reyaml'], # this must be the same as the name above
-    version = '0.2',
+    version = '0.2.1',
     long_description=LONG_DESC,
     description = 'Reader of humane YAML files',
     author = 'Alex Railean',
     author_email = 'ralienpp@gmail.com',
     url = 'https://github.com/ralienpp/reyaml',
-    download_url = 'https://github.com/ralienpp/reyaml/tarball/0.2',
+    download_url = 'https://github.com/ralienpp/reyaml/tarball/0.2.1',
     keywords = ['yaml', 'parser', 'configuration', 'config'],
     license = 'BSD',
     classifiers = [


### PR DESCRIPTION
If the file is loaded in binary mode, then comparisons need to be made in binary mode (which isn't being done).

I'm working with Python 3.5, so this may be a change between Python 2 and 3.
