### PR TITLE
Use SafeLoader when reading the yaml

### DIFF
--- a/reyaml/__init__.py
+++ b/reyaml/__init__.py
@@ -33,7 +33,7 @@ def load(raw):
                     raise SyntaxError(error)
         lines.append(line)
 
-    return yaml.load('\n'.join(lines) )
+    return yaml.load('\n'.join(lines), Loader=yaml.SafeLoader)
 
 
 def load_from_file(path):


### PR DESCRIPTION
Fix for this warning
```
/home/plugaru/.virtualenvs/roata-rest/lib/python3.8/site-packages/reyaml/__init__.py:36: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load('\n'.join(lines) )
```
[Link](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) to the description. 